### PR TITLE
make the whole caroussel picture clickable including the caption

### DIFF
--- a/app/views/pages/_carousel.html.slim
+++ b/app/views/pages/_carousel.html.slim
@@ -4,6 +4,6 @@
       .slide
         = link_to(movie) do
           = image_tag(movie.thumbnail(:max), :class => 'img-responsive img-thumbnail', :alt => "Thumbnail #{movie.title}")
-        .carousel-caption
-          h4 = movie.title.upcase
-          span.label.label-info Featured
+          .carousel-caption
+            h4 = movie.title.upcase
+            span.label.label-info Featured


### PR DESCRIPTION
I keep clicking on the featured label or the caption in the caroussel, but that doesn't work as that's not a link, just the picture.

This pull requests makes the caption and featured label clickable as well.
